### PR TITLE
Replace Fixnum with Integer

### DIFF
--- a/lib/handle/permissions.rb
+++ b/lib/handle/permissions.rb
@@ -3,7 +3,7 @@ module Handle
     attr :bitmask
 
     def initialize(*flags)
-      if flags.last.is_a?(Fixnum)
+      if flags.last.is_a?(Integer)
         @bitmask = flags.pop
       else
         @bitmask = 0


### PR DESCRIPTION
Fixnum is deprecated in Ruby 2.4; use Integer instead.